### PR TITLE
Allow arbitrary arg value

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,27 +26,18 @@ def index():
 @app.route('/<path:path>', methods=['GET', 'PUT', 'POST', 'PATCH', 'DELETE'])
 # @app.route('/<path:path>')
 def catch_all(path):
-    print('Got response')
     global REQUESTS
     global REQUESTS_LOCK
-    args = []
 
     if path == 'favicon.ico':
         return 'Not Found', 404
 
-    print('loc1')
-    print(request.is_json)
-
     if request.is_json:
-        print("JSON: {}".format(request.json))
         data = request.json
     else:
-        print(request.data)
         data = request.data
 
-    print('loc2')
     cr = CapturedRequest(str(uuid4()), path, dict(request.args), request.method, request.headers, data)
-    print("REQUEST: {}".format(cr))
 
     with REQUESTS_LOCK:
         REQUESTS.append(cr)
@@ -58,12 +49,9 @@ def catch_all(path):
     # TODO: currently this only checks the path and query args, we should add another parameter "method" so we can
     # allow users to specify different responses based on their request method of choice.
     potential_responses = RESPONSES.get(cr.path)
-    print("*****\npotential_responses: {}".format(potential_responses))
 
     if potential_responses is not None:
         for resp in potential_responses:
-            print("allowed args: {}".format(resp['args']))
-            print("got args: {}".format(cr.args))
             if resp['args'] == cr.args:
                 data = resp['response']
 
@@ -71,8 +59,6 @@ def catch_all(path):
                     return jsonify(**data)
                 else:
                     return data
-            else:
-                print('wrong args')
 
     return jsonify(success=True)
 
@@ -82,7 +68,6 @@ if __name__ == '__main__':
     parser.add_argument('port', help='The port to bind to')
     parser.add_argument('--responses', default=None, help='Path to responses file in JSON format.')
     args = parser.parse_args()
-    print('start')
 
     if args.responses:
         with open(args.responses) as f:

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def catch_all(path):
 
     if potential_responses is not None:
         for resp in potential_responses:
-            if all([resp['args'][key] == cr.args[key] or resp['args'][key] == '*' for key in cr.args.keys()]):
+            if all([resp['args'][key] == cr.args[key][0] or resp['args'][key] == '*' for key in cr.args.keys()]):
                 data = resp['response']
 
                 if isinstance(data, dict):

--- a/main.py
+++ b/main.py
@@ -34,11 +34,17 @@ def catch_all(path):
     if path == 'favicon.ico':
         return 'Not Found', 404
 
+    print('loc1')
+    print(request.is_json)
+
     if request.is_json:
+        print("JSON: {}".format(request.json))
         data = request.json
     else:
+        print(request.data)
         data = request.data
 
+    print('loc2')
     cr = CapturedRequest(str(uuid4()), path, dict(request.args), request.method, request.headers, data)
     print("REQUEST: {}".format(cr))
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,6 @@ def catch_all(path):
 
     if potential_responses is not None:
         for resp in potential_responses:
-            print(resp['args'])
             if all([resp['args'][key] == cr.args[key] or resp['args'][key] == '*' for key in cr.args.keys()]):
                 data = resp['response']
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,8 @@ def catch_all(path):
 
     if potential_responses is not None:
         for resp in potential_responses:
-            if resp['args'] == cr.args:
+            print(resp['args'])
+            if all([resp['args'][key] == cr.args[key] or resp['args'][key] == '*' for key in cr.args.keys()]):
                 data = resp['response']
 
                 if isinstance(data, dict):
@@ -72,7 +73,6 @@ if __name__ == '__main__':
     if args.responses:
         with open(args.responses) as f:
             RESPONSES = json.load(f)
-            print(RESPONSES)
 
     for resp_list in RESPONSES.values():
         for resp in resp_list:


### PR DESCRIPTION
Allow this type of format for specifying response from sham:
```
"args": {"some_input_key": ["*"]}
```
Thus, when a request is made to sham, as long as some_input_key is provided then the response returns correctly without checking against the value in the config.